### PR TITLE
Read version file path from config if available

### DIFF
--- a/H.Versioning/H.Versioning/H.Versioning.csproj
+++ b/H.Versioning/H.Versioning/H.Versioning.csproj
@@ -38,6 +38,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/H.Versioning/H.Versioning/VersionProviders/TheOneVersionProvider.cs
+++ b/H.Versioning/H.Versioning/VersionProviders/TheOneVersionProvider.cs
@@ -1,13 +1,16 @@
 ﻿using System;
+using System.Configuration;
 using System.IO;
 
 namespace H.Versioning.VersionProviders
 {
     internal sealed class TheOneVersionProvider : VersionProviderPipeline
     {
+        private static readonly string versionFile = ConfigurationManager.AppSettings["H.Versioning.VersionFile"] ?? "version.txt";
+
         public TheOneVersionProvider()
             : base(
-                  Pipe(() => File.Exists("version.txt"), new FileVersionProvider("version.txt")),
+                  Pipe(() => File.Exists(versionFile), new FileVersionProvider(versionFile)),
                   Pipe(() => true, new GitVersionProvider(AppDomain.CurrentDomain.BaseDirectory))
                   )
         { }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ H.Versioning.Version.Self.GetCurrent().ToString()
 
 then the library will parse the version from there.
 
+Alternatively, you can specify the full path of the file in a config entry with the key ```H.Versioning.VersionFile```.
+
 
 This is usefull when you deploy the app and therefore don't have access to the GIT repo.
 


### PR DESCRIPTION
This is useful for example when deploying H.Versioning as part of an IIS-hosted web app, as the current directory in that case will not be the app's root folder but rather C:\Windows\system32\inetsrv, and thus version.txt will not be found.